### PR TITLE
小小的重写了本插件,重写之后本插件可正常使用

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+**本README.md由 [@Weltolk](https://github.com/Weltolk) 编写**
+
+**2022.03.15 [@Weltolk](https://github.com/Weltolk) 更新**
+
+一.本次更新需要删除本插件以前创建并使用的表然后重新创建表
+
+- 上述操作最简单的方法:
+
+1. 更新本插件
+
+- 更新本插件的方法
+-
+    1. 在网站的插件管理页面,卸载本插件
+-
+    2. 删除网站源文件里的plugins文件夹下的wmzz_ban文件夹
+-
+    3. 下载或git clone本项目到网站源文件里的plugins文件夹下
+-
+    - 如果是下载的项目的压缩包,则解压出来本项目的文件夹然后复制到网站源文件里的plugins文件夹下
+-
+    - 如果是git clone本项目,则git clone本项目到网站源文件里的plugins文件夹下
+
+- 保证git clone或下载解压之后的目录情况:plugins/wmzz_ban/*.php
+
+2. 在网站的插件管理页面,安装和激活本插件
+
+二.本插件更新之后,封禁用户将只使用用户的portrait
+
+- 获取用户的portrait的方法:
+
+1. web端点开用户的主页
+2. url里的id参数就是portrait
+
+- 添加封禁时可以直接粘贴用户的portrait(即主页url里的id参数)或直接粘贴用户主页的url(只要粘贴的内容包含"id="和id参数即可)
+- 比如可以粘贴:
+
+1. tb.1.xxxxxxxx.xxxxxxxxxxxxxxxxxxxxxx
+2. https://tieba.baidu.com/home/main?id=tb.1.xxxxxxxx.xxxxxxxxxxxxxxxxxxxxxx&fr=pb
+3. https://tieba.baidu.com/home/main?id=tb.1.xxxxxxxx.xxxxxxxxxxxxxxxxxxxxxx
+
+- 均会自动提取出id参数
+
+**Updated on 2022.03.15**

--- a/show.php
+++ b/show.php
@@ -1,122 +1,103 @@
-<?php if (!defined('SYSTEM_ROOT')) { die('Insufficient Permissions'); } global $m,$i,$s; ?>
-<input type="button" data-toggle="modal" data-target="#banuser" class="btn btn-info btn-lg" value="+ 增加封禁" style="float:right;">
+<?php if (!defined('SYSTEM_ROOT')) {
+    die('Insufficient Permissions');
+}
+global $m, $i, $s; ?>
+<input type="button" data-toggle="modal" data-target="#banuser" class="btn btn-info btn-lg" value="+ 增加封禁"
+       style="float:right;">
 <h2>贴吧循环封禁</h2>
 
 以下为循环封禁列表，若要增加新的封禁，请点击右侧的 增加封禁 按钮
 <br/><br/>
 <table class="table table-striped">
-	<thead>
-		<tr>
-			<th>ID</th>
-			<th>PID</th>
-			<th style="width:20%">所在贴吧</th>
-			<th style="width:20%">被封禁人名字</th>
-			<th style="width:20%">TPID</th>
-			<th style="width:25%">截止日期</th>
-			<th style="width:25%">下次封禁</th>
-			<th></th>
-		</tr>
-	</thead>
-	<tbody>
-		<?php 
-		$x = $m->query("SELECT * FROM `".DB_PREFIX."wmzz_ban` WHERE `uid` = ".UID);
-		while($v = $m->fetch_array($x)) {
-		?>
-		<tr>
-			<td><?php echo $v['id'] ?></td>
-			<td><?php echo $v['pid'] ?></td>
-			<td><?php echo $v['tieba'] ?></td>
-			<td><?php echo $v['user'] ?></td>
-			<td><?php echo $v['tpid'] ?></td>
-			<td>
-			<?php if ($v['date'] == '0') {
-				echo '永久';
-			} else {
-				echo date('Y-m-d',$v['date']);
-			}
-			?></td>
-			<td><?php if(empty($v['nextdo'])) echo '即将'; else echo date('Y-m-d' , $v['nextdo'] ); ?></td>
-			<td><a class="btn btn-default" href="index.php?plugin=wmzz_ban&mod=del&id=<?php echo $v['id'] ?>" title="删除"><span class="glyphicon glyphicon-remove"></span> </a></td>
-		</tr>
-		<?php } ?>
-	</tbody>
+    <thead>
+    <tr>
+        <th>ID</th>
+        <th>PID</th>
+        <th style="width:20%">所在贴吧</th>
+        <th style="width:40%">被封禁人portrait</th>
+        <th style="width:25%">截止日期</th>
+        <th style="width:25%">下次封禁</th>
+        <th></th>
+    </tr>
+    </thead>
+    <tbody>
+    <?php
+    $x = $m->query("SELECT * FROM `" . DB_PREFIX . "wmzz_ban` WHERE `uid` = " . UID);
+    while ($v = $m->fetch_array($x)) {
+        ?>
+        <tr>
+            <td><?php echo $v['id'] ?></td>
+            <td><?php echo $v['pid'] ?></td>
+            <td><?php echo $v['tieba'] ?></td>
+            <?php
+            echo '<td><a href="http://tieba.baidu.com/home/main?id=' . $v['portrait'] . '&fr=pb' . '" target="_blank">' . $v['portrait'] . '</td>';
+            ?>
+            <td>
+                <?php if ($v['date'] == '0') {
+                    echo '永久';
+                } else {
+                    echo date('Y-m-d', $v['date']);
+                }
+                ?></td>
+            <td><?php if (empty($v['nextdo'])) echo '即将'; else echo date('Y-m-d', $v['nextdo']); ?></td>
+            <td><a class="btn btn-default" href="index.php?plugin=wmzz_ban&mod=del&id=<?php echo $v['id'] ?>"
+                   title="删除"><span class="glyphicon glyphicon-remove"></span> </a></td>
+        </tr>
+    <?php } ?>
+    </tbody>
 </table>
 
-<script type="text/javascript">
-	function conban() {
-		document.getElementById('banlist').innerHTML += '<br/><div class="input-group"><span class="input-group-addon">被封禁人百度名字</span><input type="text" name="user[]" class="form-control"></div>';
-	}
-</script>
 <div class="modal fade" id="banuser" tabindex="-1" role="dialog" aria-labelledby="banuser" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h4 class="modal-title" id="banuser_title">添加循环封禁</h4>
-      </div>
-      <form action="index.php?plugin=wmzz_ban&mod=add" method="post">
-      <div class="modal-body">
-      	要操作的贴吧名称后面不要带 <b>吧</b>，封禁截止日期格式为 yyyy-mm-dd，<b>0</b> 表示永久封禁<br/>
-      	<br/>
-      	<div class="input-group">
-			<span class="input-group-addon">选择封禁发起人账号ID [PID]</span>
-     	    <select name="pid" class="form-control" id="pid"><?php foreach ($i['user']['bduss'] as $keyyy => $valueee) {echo '<option value="'.$keyyy.'">'.$keyyy.'</option>';} ?></select>
-      	</div>
-      	<br/>
-      	<div class="input-group">
-			<span class="input-group-addon">要操作的贴吧名称</span>
-     	   	<input type="text" name="tieba" class="form-control" id="tieba">
-      	</div>
-      	<br/>
-      	<div id="banlist">
-      	<div class="input-group">
-			<span class="input-group-addon">被封禁人百度名字</span>
-     	   	<input type="text" name="user" class="form-control" id="user">
-      	</div>
-      	</div>
-      	<br/>
-      	<div class="input-group">
-			<span class="input-group-addon">贴内ID</span>
-			<span class="input-group-addon pidstatus">待获取</span>
-     	   	<input id="tpid" type="text" name="tpid" class="form-control">
-     	   	<span class="input-group-addon getpid" onclick="javascript:getPid();">自动获取</span>
-      	</div>
-      	<br/>
-      	<div class="input-group">
-			<span class="input-group-addon">封禁截止日期</span>
-     	   	<input type="text" name="date" class="form-control" value="0">
-      	</div>
-      </div>
-      <div class="modal-footer">
-      	<button type="button" class="btn btn-info" style="float:left;" onclick="conban()">继续添加</button>
-        <button type="button" class="btn btn-default" data-dismiss="modal">取消</button>
-        <button type="submit" class="btn btn-primary" id="runsql_button">提交更改</button>
-      </div>
-      </form>
-    </div><!-- /.modal-content -->
-  </div><!-- /.modal-dialog -->
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title" id="banuser_title">添加循环封禁</h4>
+            </div>
+            <form action="index.php?plugin=wmzz_ban&mod=add" method="post">
+                <div class="modal-body">
+                    要操作的贴吧名称后面不要带 <b>吧</b><br/>封禁截止日期格式为 yyyy-mm-dd，<b>0</b>
+                    表示永久封禁<br/>web端点开用户主页，url里的id参数就是portrait<br/>
+                    <br/>
+                    <div class="input-group">
+                        <span class="input-group-addon">选择封禁发起人账号ID [PID]</span>
+                        <select name="pid" class="form-control"
+                                id="pid"><?php
+                            echo '<option value="' . $s["pid"] . '" selected hidden>' . $s["pid"] . '</option>'; ?>
+                            <?php foreach ($i['user']['bduss'] as $keyyy => $valueee) {
+                                echo '<option value="' . $keyyy . '">' . $keyyy . '</option>';
+                            }
+                            ?></select>
+                    </div>
+                    <br/>
+                    <div class="input-group">
+                        <span class="input-group-addon">要操作的贴吧名称</span>
+                        <?php echo '<input type="text" name="tieba" class="form-control" id="tieba" value="' . $s["tieba"] . '">'; ?>
+                    </div>
+                    <br/>
+                    <div id="banlist">
+                        <div class="input-group">
+                            <span class="input-group-addon">被封禁人portrait<br/><br/>1.可添加多个<br/><br/>用回车分隔<br/><br/>2.支持直接粘贴<br/><br/>用户主页的url<br/><br/>可以自动提取portrait</span>
+                            <textarea class="form-control" name="portrait" style="height:300px;"></textarea>
+                            <!--                            <input type="text" name="portrait" class="form-control" id="portrait">-->
+                        </div>
+                    </div>
+                    <br/>
+                    <div class="input-group">
+                        <span class="input-group-addon">封禁截止日期</span>
+                        <input type="text" name="date" class="form-control" value="0">
+                    </div>
+                    <br/>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">取消</button>
+                    <button type="submit" class="btn btn-primary" id="runsql_button">提交更改</button>
+                </div>
+            </form>
+        </div><!-- /.modal-content -->
+    </div><!-- /.modal-dialog -->
 </div><!-- /.modal -->
 <br/><br/>管理员设置的循环封禁理由：<?php echo $s['msg'] ?>
+<br/><br/>管理员设置的默认封禁的贴吧：<?php echo $s['tieba'] ?>
+<br/><br/>管理员设置的默认执行封禁的id：<?php echo $s['pid'] ?>
 <br/><br/>作者：<a href="http://zhizhe8.net" target="_blank">无名智者</a>
-<script type="text/javascript">
-	function getPid(){
-		var user = $("#user").val()
-		var tieba = $("#tieba").val()
-		var pid = $("#pid").val();
-		$.ajax({
-			url:'/index.php?plugin=wmzz_ban&mod=getpid&pid='+pid+'&user='+user+'&tieba='+tieba+'&t_='+ Date.parse(new Date()),
-			type:'post',
-			dataType:'json',
-			success:function(data){
-				if(data.status == 'ok'){
-					$(".pidstatus").html('自动获取成功')
-					$(".pidstatus").css("color","#00CD66")
-					$("#tpid").val(data.pid)
-					return
-				}
-				$(".pidstatus").html('自动获取失败')
-				$(".pidstatus").css("color","#CD2626")
-			}
-		})
-	}
-</script>

--- a/wmzz_ban.php
+++ b/wmzz_ban.php
@@ -9,20 +9,27 @@ Author Email: kenvix@vip.qq.com
 Author URL: http://zhizhe8.net
 For: V3.1+
 */
-if (!defined('SYSTEM_ROOT')) { die('Insufficient Permissions'); } 
-
-function wmzz_ban_addaction_navi() {
-	?>
-	<li <?php if(isset($_GET['plugin']) && $_GET['plugin'] == 'wmzz_ban') { echo 'class="active"'; } ?>><a href="index.php?plugin=wmzz_ban"><span class="glyphicon glyphicon-ban-circle"></span> 循环封禁</a></li>
-	<?php
+if (!defined('SYSTEM_ROOT')) {
+    die('Insufficient Permissions');
 }
 
-function wmzz_ban_setting_navi() {
-	?>
-	<li><a href="index.php?mod=admin:setplug&plug=wmzz_ban"><span class="glyphicon glyphicon-ban-circle"></span> 循环封禁管理</a></li>
-	<?php
+function wmzz_ban_addaction_navi()
+{
+    ?>
+    <li <?php if (isset($_GET['plugin']) && $_GET['plugin'] == 'wmzz_ban') {
+        echo 'class="active"';
+    } ?>><a href="index.php?plugin=wmzz_ban"><span class="glyphicon glyphicon-ban-circle"></span> 循环封禁</a></li>
+    <?php
 }
 
-addAction('navi_1','wmzz_ban_addaction_navi');
-addAction('navi_7','wmzz_ban_addaction_navi');
-addAction('navi_3','wmzz_ban_setting_navi');
+function wmzz_ban_setting_navi()
+{
+    ?>
+    <li><a href="index.php?mod=admin:setplug&plug=wmzz_ban"><span class="glyphicon glyphicon-ban-circle"></span> 循环封禁管理</a>
+    </li>
+    <?php
+}
+
+addAction('navi_1', 'wmzz_ban_addaction_navi');
+addAction('navi_7', 'wmzz_ban_addaction_navi');
+addAction('navi_3', 'wmzz_ban_setting_navi');

--- a/wmzz_ban_callback.php
+++ b/wmzz_ban_callback.php
@@ -1,15 +1,17 @@
 <?php
-if (!defined('SYSTEM_ROOT')) { die('Insufficient Permissions'); }
+if (!defined('SYSTEM_ROOT')) {
+    die('Insufficient Permissions');
+}
 
-function callback_init() {
-	global $m;
-	$m->query("CREATE TABLE IF NOT EXISTS `".DB_PREFIX."wmzz_ban` (
+function callback_init()
+{
+    global $m;
+    $m->query("CREATE TABLE IF NOT EXISTS `" . DB_PREFIX . "wmzz_ban` (
 `id`  int(255) NOT NULL AUTO_INCREMENT ,
 `uid`  int(255) NOT NULL ,
 `pid`  int(255) NOT NULL ,
 `tieba`  varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL ,
-`user`  varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL ,
-`tpid`  varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL ,
+`portrait`  varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL ,
 `date`  varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT '0' ,
 `nextdo`  varchar(255) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT '0' ,
 PRIMARY KEY (`id`)
@@ -20,17 +22,27 @@ AUTO_INCREMENT=12
 CHECKSUM=0
 ROW_FORMAT=DYNAMIC
 DELAY_KEY_WRITE=0;");
-	option::set('plugin_wmzz_ban','a:2:{s:5:"limit";s:2:"10";s:3:"msg";s:63:"由于你违反了吧规，现在已被本吧管理循环封禁";}');
-	cron::set('wmzz_ban','plugins/wmzz_ban/wmzz_ban_cron.php',0,0,0);
+    $set_arr = array(
+        'limit' => "10",
+        'msg' => "大量散布广告，发表交易帖，屡教不改，给予封禁处罚。",
+        'pid' => "",
+        'tieba' => "",
+    );
+    $set_str = serialize($set_arr);
+    option::set('plugin_wmzz_ban', $set_str);
+    cron::set('wmzz_ban', 'plugins/wmzz_ban/wmzz_ban_cron.php', 0, 0, 0);
 }
 
-function callback_inactive() {
-	cron::del('wmzz_ban');
+function callback_inactive()
+{
+    cron::del('wmzz_ban');
 }
 
-function callback_remove() {
-	global $m;
-	$m->query("DROP TABLE IF EXISTS `".DB_PREFIX."wmzz_ban`");
-	option::del('plugin_wmzz_ban');
+function callback_remove()
+{
+    global $m;
+    $m->query("DROP TABLE IF EXISTS `" . DB_PREFIX . "wmzz_ban`");
+    option::del('plugin_wmzz_ban');
 }
+
 ?>

--- a/wmzz_ban_cron.php
+++ b/wmzz_ban_cron.php
@@ -1,45 +1,50 @@
-<?php if (!defined('SYSTEM_ROOT')) { die('Insufficient Permissions'); }
+<?php if (!defined('SYSTEM_ROOT')) {
+    die('Insufficient Permissions');
+}
 
 /**
  * 获取封禁类型
  * @param $date 封禁截止日期
  */
-function wmzz_ban_getTime($date) {
-	return '1';
+function wmzz_ban_getTime($date)
+{
+    return '1';
 }
 
-function cron_wmzz_ban() {
-	global $m;
-	$s = unserialize(option::get('plugin_wmzz_ban'));
-	$now   = strtotime(date('Y-m-d'));
-	$y = $m->query("SELECT * FROM `".DB_PREFIX."wmzz_ban` WHERE `nextdo` <= '{$now}' LIMIT {$s['limit']}");
-	while ($x = $m->fetch_array($y)) {
-		$r = wmzz_ban_getTime($x['date']);
-		if ($r != '-1') {
-			$bduss = misc::getCookie($x['pid']);
-			$c = new wcurl('http://tieba.baidu.com/pmc/blockid');
-			$c->addcookie('BDUSS='.$bduss);
-			$option = array(
-				'user_name[]' => $x['user'],
-				'day' => $r,
-				'fid' => misc::getFid($x['tieba']),
-				'tbs' => misc::getTbs($x['uid'] , $bduss),
-				'ie' => 'utf-8',
-				'reason' => $s['msg']
-			);
-			if(!empty($x['tpid'])){
-				$option['pid[]']  = $x['tpid'];
-			}
-			$res = $c->post($option);
-			$res = json_decode($res,TRUE);
-			if($res['errno'] == 0){
-				$next = $now + ( $r * 86400 );
-				$m->query("UPDATE `".DB_PREFIX."wmzz_ban` SET `nextdo` = '{$next}' WHERE `id` = '{$x['id']}'");
-			} else if( $res['errno'] == 74 ){    //用户名不存在   224011 需要验证码
-				$m->query("DELETE FROM `".DB_PREFIX."wmzz_ban` WHERE `id` = '{$x['id']}'");
-			}
-		} else {
-			$m->query("DELETE FROM `".DB_PREFIX."wmzz_ban` WHERE `id` = '{$x['id']}'");
-		}
-	}
+function cron_wmzz_ban()
+{
+    global $m;
+    $s = unserialize(option::get('plugin_wmzz_ban'));
+    $now = strtotime(date('Y-m-d'));
+    $y = $m->query("SELECT * FROM `" . DB_PREFIX . "wmzz_ban` WHERE `nextdo` <= '{$now}' LIMIT {$s['limit']}");
+    while ($x = $m->fetch_array($y)) {
+        $r = wmzz_ban_getTime($x['date']);
+        if ($r != '-1') {
+            $bduss = misc::getCookie($x['pid']);
+            $c = new wcurl('http://tieba.baidu.com/pmc/blockid');
+            $c->addcookie('BDUSS=' . $bduss);
+            $option = array(
+                'day' => $r,
+                'fid' => misc::getFid($x['tieba']),
+                'tbs' => misc::getTbs($x['uid'], $bduss),
+//                'ie' => 'utf-8',
+                'ie' => 'gbk',
+                'user_name[]' => '',
+                'nick_name[]' => '',
+                'portrait[]' => $x['portrait'],
+                'pid[]' => '',
+                'reason' => $s['msg']
+            );
+            $res = $c->post($option);
+            $res = json_decode($res, TRUE);
+            if ($res['errno'] == 0) {
+                $next = $now + ($r * 86400);
+                $m->query("UPDATE `" . DB_PREFIX . "wmzz_ban` SET `nextdo` = '{$next}' WHERE `id` = '{$x['id']}'");
+            } else if ($res['errno'] == 74) {    //用户名不存在   224011 需要验证码
+                $m->query("DELETE FROM `" . DB_PREFIX . "wmzz_ban` WHERE `id` = '{$x['id']}'");
+            }
+        } else {
+            $m->query("DELETE FROM `" . DB_PREFIX . "wmzz_ban` WHERE `id` = '{$x['id']}'");
+        }
+    }
 }

--- a/wmzz_ban_setting.php
+++ b/wmzz_ban_setting.php
@@ -1,31 +1,60 @@
 <?php
-if (!defined('SYSTEM_ROOT')) { die('Insufficient Permissions'); } 
+if (!defined('SYSTEM_ROOT')) {
+    die('Insufficient Permissions');
+}
+
+global $i, $m;
 
 $s = unserialize(option::get('plugin_wmzz_ban'));
 
 if (isset($_GET['ok'])) {
-	echo '<div class="alert alert-success">设置保存成功</div>';
+    echo '<div class="alert alert-success">设置保存成功</div>';
 }
 ?>
 <h3>循环封禁 - 管理</h3><br/>
 <form action="setting.php?mod=plugin:wmzz_ban" method="post">
-<table class="table table-striped">
-	<thead>
-		<tr>
-			<th style="width:45%">参数</th>
-			<th style="width:55%">值</th>
-		</tr>
-	</thead>
-	<tbody>
-		<tr>
-			<td>单次计划任务连续封禁次数<br/>越小效率越低，但太大也可能导致超时</td>
-			<td><input type="number" min="1" step="1" name="limit" value="<?php echo $s['limit'] ?>"  class="form-control" required></td>
-		</tr>
-		<tr>
-			<td>被封禁提示语句</td>
-			<td><input type="text" value="<?php echo $s['msg'] ?>" name="msg" class="form-control" required></td>
-		</tr>
-	</tbody>
-</table>
-<br/><br/><button type="submit" class="btn btn-success">保存设定</button>
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th style="width:45%">参数</th>
+            <th style="width:55%">值</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>单次计划任务连续封禁次数<br/>越小效率越低，但太大也可能导致超时</td>
+            <td><input type="number" min="1" step="1" name="limit" value="<?php echo $s['limit'] ?>"
+                       class="form-control" required></td>
+        </tr>
+        <tr>
+            <td>被封禁提示语句</td>
+            <td><input type="text" value="<?php echo $s['msg'] ?>" name="msg" class="form-control" required></td>
+        </tr>
+        <tr>
+            <td>默认封禁的贴吧</td>
+            <td><input type="text" value="<?php echo $s['tieba'] ?>" name="tieba" class="form-control"></td>
+        </tr>
+        <tr>
+            <td>默认执行封禁的id</td>
+            <td><select name="pid" class="form-control" id="pid">
+                    <option value=""></option><?php if (empty($s["pid"])) {
+                        echo '<option selected disabled hidden value=""></option>';
+                        foreach ($i['user']['bduss'] as $keyyy => $valueee) {
+                            echo '<option value="' . $keyyy . '">' . $keyyy . '</option>';
+                        }
+                    } else {
+                        echo '<option disabled hidden value=""></option>';
+                        foreach ($i['user']['bduss'] as $keyyy => $valueee) {
+                            if ($keyyy == $s["pid"]) {
+                                echo '<option selected value="' . $keyyy . '">' . $keyyy . '</option>';
+                            } else {
+                                echo '<option value="' . $keyyy . '">' . $keyyy . '</option>';
+                            }
+                        }
+                    } ?></select></td>
+        </tr>
+        </tbody>
+    </table>
+    <br/><br/>
+    <button type="submit" class="btn btn-success">保存设定</button>
 </form>

--- a/wmzz_ban_show.php
+++ b/wmzz_ban_show.php
@@ -1,66 +1,51 @@
-<?php if (!defined('SYSTEM_ROOT')) { die('Insufficient Permissions'); }  
-global $i,$m;
+<?php if (!defined('SYSTEM_ROOT')) {
+    die('Insufficient Permissions');
+}
+global $i, $m;
 $s = unserialize(option::get('plugin_wmzz_ban'));
 if (SYSTEM_PAGE == 'add') {
-	$pid   = !empty($_POST['pid']) ? intval($_POST['pid']) : msg('请选择PID');
-	if (!isset($i['user']['bduss'][$pid])) {
-		msg('PID不存在');
-	}
-	$tieba = !empty($_POST['tieba']) ? addslashes(strip_tags($_POST['tieba'])) : msg('请输入贴吧');
-	if (isset($_POST['date'])) {
-		if (empty($_POST['date'])) {
-			$date = '0';
-		} else {
-			$date = strtotime($_POST['date']);
-		}
-	} else {
-		msg('请输入截止日期');
-	}
-	$value = addslashes(strip_tags($_POST['user']));
-	$tpid = $_POST['tpid'];
-	$m->query("INSERT INTO `".DB_PREFIX."wmzz_ban` (`uid`, `pid`, `tieba`, `user`, `tpid` , `date`) VALUES ('".UID."', '{$pid}', '{$tieba}', '{$value}', '{$tpid}', '{$date}')");
-	ReDirect(SYSTEM_URL . 'index.php?plugin=wmzz_ban&ok');
+    $pid = !empty($_POST['pid']) ? intval($_POST['pid']) : msg('请选择PID');
+    if (!isset($i['user']['bduss'][$pid])) {
+        msg('PID不存在');
+    }
+    $tieba = !empty($_POST['tieba']) ? addslashes(strip_tags($_POST['tieba'])) : msg('请输入贴吧');
+    $portrait = !empty($_POST['portrait']) ? addslashes(strip_tags($_POST['portrait'])) : msg('请输入被封禁人portrait');
+    $portrait = explode("\n", trim($portrait));
+    if (isset($_POST['date'])) {
+        if (empty($_POST['date'])) {
+            $date = '0';
+        } else {
+            $date = strtotime($_POST['date']);
+        }
+    } else {
+        msg('请输入截止日期');
+    }
+    $prefix = "id=tb.";
+    $suffix1 = "&";
+    $suffix2 = "?";
+    foreach ($portrait as $portrait_i) {
+        $portrait_i = trim($portrait_i);
+        if (!empty($portrait_i)) {
+            if (strpos($portrait_i, $prefix)) {
+                $portrait_i = "tb." . explode($prefix, $portrait_i)[1];
+            }
+            if (strpos($portrait_i, $suffix1)) {
+                $portrait_i = explode($suffix1, $portrait_i)[0];
+            }
+            if (strpos($portrait_i, $suffix2)) {
+                $portrait_i = explode($suffix2, $portrait_i)[0];
+            }
+//            if(strlen($portrait_i)=="")
+            $m->query("INSERT INTO `" . DB_PREFIX . "wmzz_ban` (`uid`, `pid`, `tieba`, `portrait` , `date`) VALUES ('" . UID . "', '{$pid}', '{$tieba}', '{$portrait_i}', '{$date}')");
+        }
+    }
+    ReDirect(SYSTEM_URL . 'index.php?plugin=wmzz_ban&ok');
 } elseif (SYSTEM_PAGE == 'del') {
-	$id = isset($_GET['id']) ? intval($_GET['id']) : msg('缺少ID');
-	$m->query("DELETE FROM `".DB_PREFIX."wmzz_ban` WHERE `uid` = ".UID." AND `id` = ".$id);
-	ReDirect(SYSTEM_URL . 'index.php?plugin=wmzz_ban&ok');
-} elseif(SYSTEM_PAGE == 'getpid'){
-	$username = $_GET['user'];
-	$tieba = $_GET['tieba'];
-	$pid = $_GET['pid'];
-	$option = array(
-		'word' => mb_convert_encoding($tieba,'gbk','UTF-8'),
-		'op_type' => '',
-		'stype' => 'post_uname',
-		'svalue' =>  mb_convert_encoding($username,'gbk','UTF-8'),
-		'date_type' => 'on',
-		'startTime' => '',
-		'begin' => '',
-		'endTime' => '',
-		'end' => ''
-	);
-	$bduss = misc::getCookie($pid);
-	$query = http_build_query($option);
-	$c = new wcurl('http://tieba.baidu.com/bawu2/platform/listPostLog?'. $query);
-	$c->addcookie('BDUSS='.$bduss);
-	$html = $c->get();
-	$html = mb_convert_encoding($html,'UTF-8','gbk');
-	$preg ="/<article class=\"post_wrapper clearfix\"><div class=\"post_meta\"><div class=\"post_author\">.*?<h1><a target=\"_blank\" href=\".*?pid=(.*?)\".*?<\/article>/i";
-	preg_match_all($preg, $html, $info);
-	$pid = [];
-	foreach ($info[1] as $value) {
-		$pidarray = explode('#',$value);
-		$pid[] = (float)$pidarray[1];
-		$pid[] = (float)$pidarray[0];
-	}
-	$maxpid =  max($pid);
-	if($maxpid > 100000000000){
-		echo json_encode(array('status' => 'ok','pid'=>$maxpid));
-		return;
-	}
-	echo json_encode(array('status' => 'error'));
-}else {
-	loadhead();
-	require SYSTEM_ROOT.'/plugins/wmzz_ban/show.php';
-	loadfoot(); 
+    $id = isset($_GET['id']) ? intval($_GET['id']) : msg('缺少ID');
+    $m->query("DELETE FROM `" . DB_PREFIX . "wmzz_ban` WHERE `uid` = " . UID . " AND `id` = " . $id);
+    ReDirect(SYSTEM_URL . 'index.php?plugin=wmzz_ban&ok');
+} else {
+    loadhead();
+    require SYSTEM_ROOT . '/plugins/wmzz_ban/show.php';
+    loadfoot();
 } 


### PR DESCRIPTION
完整的修复了本插件

测试时使用的相关python代码:

```
def get_tbs(bduss: str) -> str:
    url = "http://tieba.baidu.com/dc/common/tbs"
    headers = {
        "Cookie": "BDUSS=" + bduss,
        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.51 Safari/537.36 Edg/99.0.1150.39",
        "Referer": "http://tieba.baidu.com/",
        "X-Forwarded-For": str(random.randint(0, 255)) + str(random.randint(0, 255)) + str(
            random.randint(0, 255)) + str(random.randint(0, 255)),
    }
    session = requests.Session()
    result = session.get(url=url, headers=headers)
    session.close()
    tbs = json.loads(result.text)
    return tbs["tbs"]


def block(bduss: str, fid: str, day: str = "1", user: str = "", nick: str = "", pid: str = "", portrait: str = "",
          reason: str = "大量散布广告，发表交易帖，屡教不改，给予封禁处罚。") -> bool:
    tbs = get_tbs(bduss)
    url = "http://tieba.baidu.com/pmc/blockid"
    headers = {
        "Cookie": "BDUSS=" + bduss,
    }
    data = {
        "day": day,
        "fid": fid,
        "tbs": tbs,
        "ie": "gbk",
        "user_name[]": user,
        "nick_name[]": nick,
        "pid[]": pid,
        "portrait[]": portrait,
        "reason": reason,
    }
    print(headers)
    print(data)
    session = requests.Session()
    block_result = session.post(url=url, headers=headers, data=data)
    session.close()
    print(block_result.text)
    return True


if __name__ == "__main__":
    pass
    bduss = "xxxx"
    fid = "11111111"

    user = "xxxx"
    nick = "xxxx"
    pid = "111111111111"
    portrait = "tb.1.xxxxxxxx.xxxxxxxxxxxxxxxxxxxxxx"
    user = ""
    nick = ""
    pid = ""
    # portrait = ""

    # portrait
    result = block_result = block(bduss=bduss, fid=fid, user=user, nick=nick, pid=pid, portrait=portrait)
```

程序输出:

```
{'Cookie': 'BDUSS=xxxx'}
{'day': '1', 'fid': '11111111', 'tbs': 'xxxxxxxxxxxxxxxxxxxxxxxxxx', 'ie': 'gbk', 'user_name[]': '', 'nick_name[]': '', 'pid[]': '', 'portrait[]': 'tb.1.xxxxxxxx.xxxxxxxxxxxxxxxxxxxxxx', 'reason': '大量散布广告，发表交易帖，屡教不改，给予封禁处罚。'}
{"errno":0,"errmsg":"\u6210\u529f"}
```

经过测试,通过上述方法封禁用户时,单指定user_name[],nick_name[]或pid[]均不能成功封禁,但是单指定portrait[]可以封禁成功 上述四个参数的组合我没有测试,因为我没有找到方法根据user_name[]
,nick_name[]和显示的名字这三个其中的某一个找到其他的 也是因为上述原因,所以我选择了使用portrait[]来做为封禁的参数 且portrait[]
相对易获取,web端进入要封禁的用户的主页,url里的id参数就是该用户的portrait[]
