### PR TITLE
Update wmzz_ban_show.php,防止插入重复数据,当新添加的循环封禁信息和现存数据完全相同时,不执行任何操作

### DIFF
--- a/wmzz_ban_show.php
+++ b/wmzz_ban_show.php
@@ -36,7 +36,11 @@ if (SYSTEM_PAGE == 'add') {
                 $portrait_i = explode($suffix2, $portrait_i)[0];
             }
 //            if(strlen($portrait_i)=="")
-            $m->query("INSERT INTO `" . DB_PREFIX . "wmzz_ban` (`uid`, `pid`, `tieba`, `portrait` , `date`) VALUES ('" . UID . "', '{$pid}', '{$tieba}', '{$portrait_i}', '{$date}')");
+            $m->query("INSERT INTO `" . DB_PREFIX . "wmzz_ban` (`uid`, `pid`, `tieba`, `portrait` , `date`)"
+                . " SELECT '" . UID . "', '{$pid}', '{$tieba}', '{$portrait_i}', '{$date}'"
+                . " WHERE NOT EXISTS ( SELECT * FROM `" . DB_PREFIX . "wmzz_ban`"
+                . " WHERE `uid` = '" . UID . "' AND `pid` = '{$pid}' AND `tieba` = '{$tieba}'"
+                . " AND `portrait` = '{$portrait_i}' AND `date` = '{$date}')");
         }
     }
     ReDirect(SYSTEM_URL . 'index.php?plugin=wmzz_ban&ok');


### PR DESCRIPTION
当前添加循环封禁需要提供贴吧云签到的账号uid,贴吧云签到添加的贴吧账号的pid,贴吧名,要封禁的用户的portrait和日期
本次更新之后,当新添加的循环封禁的信息和数据库里的某条数据上述5项信息完全相同时,不会进行任何操作